### PR TITLE
[BUGFIX] Fix PHP8 issues in backend

### DIFF
--- a/Classes/Backend/Filterlist.php
+++ b/Classes/Backend/Filterlist.php
@@ -174,7 +174,7 @@ class Filterlist
                     }
                 }
 
-                if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyFilteroptionsForFlexforms'])) {
+                if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyFilteroptionsForFlexforms'] ?? null)) {
                     foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyFilteroptionsForFlexforms'] as
                              $_classRef) {
                         $_procObj = GeneralUtility::makeInstance($_classRef);

--- a/Classes/Backend/Filterlist.php
+++ b/Classes/Backend/Filterlist.php
@@ -82,7 +82,7 @@ class Filterlist
 
         // get the page TSconfig
         $pageTSconfig = BackendUtility::GetPagesTSconfig($currentPid);
-        $modTSconfig = $pageTSconfig['tx_kesearch.'];
+        $modTSconfig = $pageTSconfig['tx_kesearch.'] ?? [];
 
         // get filters
         $fields = '*';

--- a/Classes/Backend/Flexform.php
+++ b/Classes/Backend/Flexform.php
@@ -45,7 +45,7 @@ class Flexform
 
         // get orderings
         $fieldLabel = $this->lang->sL('LLL:EXT:ke_search/Resources/Private/Language/locallang_db.xlf:tx_kesearch_index.relevance');
-        if (!$config['config']['relevanceNotAllowed']) {
+        if (!($config['config']['relevanceNotAllowed'] ?? false)) {
             $config['items'][] = array($fieldLabel . ' UP', 'score asc');
             $config['items'][] = array($fieldLabel . ' DOWN', 'score desc');
         }

--- a/Classes/Controller/AbstractBackendModuleController.php
+++ b/Classes/Controller/AbstractBackendModuleController.php
@@ -63,7 +63,7 @@ abstract class AbstractBackendModuleController extends ActionController
             $this->argumentsKey
         );
 
-        if ($moduleData['action'] === 'alert') {
+        if (($moduleData['action'] ?? '') === 'alert') {
             return;
         }
 

--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -398,7 +398,7 @@ class Page extends IndexerBase
                 if ($removeRestrictions) {
                     $queryBuilder->getRestrictions()->removeAll();
                 }
-                list($pageOverlay) = $queryBuilder
+                $results = $queryBuilder
                     ->select('*')
                     ->from('pages')
                     ->where(
@@ -414,6 +414,7 @@ class Page extends IndexerBase
                     ->execute()
                     ->fetchAll();
 
+                $pageOverlay = $results[0] ?? false;
                 if ($pageOverlay) {
                     $this->cachedPageRecords[$sysLang['uid']][$pageRow['uid']] = $pageOverlay + $pageRow;
                 }


### PR DESCRIPTION
This fixes the following issues:

    An error occurred trying to process items for field "Tags for faceted search" (PHP Warning: Undefined array key "tx_kesearch." in /var/www/html/public/typo3conf/ext/ke_search/Classes/Backend/Filterlist.php line 85).

    An error occurred trying to process items for field "Sorting for searchresults" (PHP Warning: Undefined array key "relevanceNotAllowed" in /var/www/html/public/typo3conf/ext/ke_search/Classes/Backend/Flexform.php line 48).

    PHP Warning: Undefined array key 0 in /var/www/html/public/typo3conf/ext/ke_search/Classes/Indexer/Types/Page.php line 415