### PR TITLE
[TASK] Remove PHP 8.1 deprecations

### DIFF
--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -1042,7 +1042,7 @@ class Page extends IndexerBase
 
         /** @var LinkService $linkService */
         $linkService = GeneralUtility::makeInstance(LinkService::class);
-        $blockSplit = $rteHtmlParser->splitIntoBlock('A', $ttContentRow['bodytext'], 1);
+        $blockSplit = $rteHtmlParser->splitIntoBlock('A', (string)$ttContentRow['bodytext'], 1);
         foreach ($blockSplit as $k => $v) {
             list($attributes) = $rteHtmlParser->get_tag_attributes($rteHtmlParser->getFirstTag($v), true);
             if (!empty($attributes['href'])) {
@@ -1178,7 +1178,7 @@ class Page extends IndexerBase
     public function getContentFromContentElement($ttContentRow)
     {
         // bodytext
-        $bodytext = $ttContentRow['bodytext'];
+        $bodytext = (string)$ttContentRow['bodytext'];
 
         // following lines prevents having words one after the other like: HelloAllTogether
         $bodytext = str_replace('<td', ' <td', $bodytext);


### PR DESCRIPTION
This fixes the following deprecations:

    PHP Runtime Deprecation Notice: preg_split(): Passing null to parameter #2 ($subject) of type string is deprecated in /var/www/html/public/typo3/sysext/core/Classes/Html/HtmlParser.php line 60
    PHP Runtime Deprecation Notice: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/html/public/typo3conf/ext/ke_search/Classes/Indexer/Types/Page.php line 1190

The first one is caused due to passing a null value as 2nd argument to method $rteHtmlParser->splitIntoBlock().