### PR TITLE
[TASK] Use .Build folder for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.Build
 .idea
+composer.lock
 vendor
 .DS_Store
 Tests/Behat/vendor

--- a/composer.json
+++ b/composer.json
@@ -38,13 +38,16 @@
   },
   "extra": {
     "typo3/cms": {
-      "extension-key": "ke_search"
+      "extension-key": "ke_search",
+      "web-dir": ".Build/web"
     }
   },
   "config": {
     "allow-plugins": {
       "typo3/class-alias-loader": true,
       "typo3/cms-composer-installers": true
-    }
+    },
+    "bin-dir": ".Build/bin",
+    "vendor-dir": ".Build/vendor"
   }
 }


### PR DESCRIPTION
The dependencies (in the vendor folder) and the public folder (named then "web")
are moved into a .Build folder. This way it can be easily ignored and deleted
when necessary.

This is a common pattern in TYPO3 extensions, like TYPO3 console:
https://github.com/TYPO3-Console/TYPO3-Console/blob/latest/composer.json