### PR TITLE
[TASK] Register icons via service container

### DIFF
--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -1,0 +1,10 @@
+<?php
+
+use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+
+return [
+    'ext-kesearch-wizard-icon' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:ke_search/Resources/Public/Icons/moduleicon.svg'
+    ],
+];

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -31,11 +31,15 @@ defined('TYPO3') or die();
         'description' => 'This task updates the ke_search index (DEPRECATED, please use "Execute console commands" --> "ke_search:indexing" instead)'
     );
 
-    /** @var \TYPO3\CMS\Core\Imaging\IconRegistry $iconRegistry */
-    $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
-    $iconRegistry->registerIcon(
-        'ext-kesearch-wizard-icon',
-        'TYPO3\CMS\Core\Imaging\IconProvider\BitmapIconProvider',
-        ['source' => 'EXT:ke_search/Resources/Public/Icons/moduleicon.svg']
-    );
+    if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() === 10) {
+        // This icon registration can be deleted once compatibility with TYPO3 v10 is removed
+        // see also: Configuration/Icons.php for the new way
+        /** @var \TYPO3\CMS\Core\Imaging\IconRegistry $iconRegistry */
+        $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
+        $iconRegistry->registerIcon(
+            'ext-kesearch-wizard-icon',
+            \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+            ['source' => 'EXT:ke_search/Resources/Public/Icons/moduleicon.svg']
+        );
+    }
 })();


### PR DESCRIPTION
This way the loading speed is improved for every request in TYPO3 v11+.
See also: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Feature-94692-RegisteringIconsViaServiceContainer.html

Additionally, the SVG provider is used for icon registering in TYPO3 v10 instead
of the bitmap provider.