### PR TITLE
[TASK] Avoid PHP 8.1 deprecations when indexing

### DIFF
--- a/Classes/Indexer/Types/News.php
+++ b/Classes/Indexer/Types/News.php
@@ -252,7 +252,7 @@ class News extends IndexerBase
                             : $newsRecord['uid'];
                         $paramsSingleView['tx_news_pi1']['controller'] = 'News';
                         $paramsSingleView['tx_news_pi1']['action'] = 'detail';
-                        $params = '&' . http_build_query($paramsSingleView, null, '&');
+                        $params = '&' . http_build_query($paramsSingleView, '', '&');
                         $params = rawurldecode($params);
                     }
                 }

--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -773,9 +773,8 @@ class Page extends IndexerBase
                     }
 
                     // use tx_kesearch_abstract instead of "abstract" if set
-                    $abstract = $this->cachedPageRecords[$language_uid][$uid]['tx_kesearch_abstract'] ?
-                        $this->cachedPageRecords[$language_uid][$uid]['tx_kesearch_abstract'] :
-                        $this->cachedPageRecords[$language_uid][$uid]['abstract'];
+                    $abstract = (string)($this->cachedPageRecords[$language_uid][$uid]['tx_kesearch_abstract']
+                        ?: $this->cachedPageRecords[$language_uid][$uid]['abstract']);
 
                     $this->pObj->storeInIndex(
                         $indexerConfig['storagepid'],                               // storage PID


### PR DESCRIPTION
    PHP Runtime Deprecation Notice: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/html/public/typo3conf/ext/ke_search/Classes/Indexer/IndexerRunner.php line 1169

The upper message is caused by the abstract of a page to be null. The abstract is therefore casted to a string,
as storeInIndex() is expecting a string according to the annotation.

    PHP Runtime Deprecation Notice: http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated in /var/www/html/public/typo3conf/ext/ke_search/Classes/Indexer/Types/News.php line 255