### PR TITLE
[BUGFIX] Display hours in status widget correctly

### DIFF
--- a/Classes/Widgets/StatusWidget.php
+++ b/Classes/Widgets/StatusWidget.php
@@ -61,8 +61,8 @@ class StatusWidget implements WidgetInterface
         $indexerRunningTimeHMS =
             $indexerRunningTime ?
                 [
-                    's' => round($indexerRunningTime / 3600),
-                    'm' => $indexerRunningTime / 60 % 60,
+                    'h' => floor($indexerRunningTime / 3600),
+                    'm' => (int)($indexerRunningTime / 60) % 60,
                     's' => $indexerRunningTime % 60
                 ]
                 : [];
@@ -78,8 +78,8 @@ class StatusWidget implements WidgetInterface
             $lastRunIndexingTimeHMS =
                 $lastRun['indexingTime'] ?
                 [
-                    's' => round($lastRun['indexingTime'] / 3600),
-                    'm' => $lastRun['indexingTime'] / 60 % 60,
+                    'h' => floor($lastRun['indexingTime'] / 3600),
+                    'm' => (int)($lastRun['indexingTime'] / 60) % 60,
                     's' => $lastRun['indexingTime'] % 60
                 ]
                 : [];


### PR DESCRIPTION
The hours are not assigned correctly to the view. Also, in the hours calculation the number was rounded, instead it must be floor'ed.

Additionally, two deprecations in PHP 8.1 were fixed:

    PHP Runtime Deprecation Notice: Implicit conversion from float 2.0166666666666666 to int loses precision in /var/www/html/public/typo3conf/ext/ke_search/Classes/Widgets/StatusWidget.php line 65
    PHP Runtime Deprecation Notice: Implicit conversion from float 0.13333333333333333 to int loses precision in /var/www/html/public/typo3conf/ext/ke_search/Classes/Widgets/StatusWidget.php line 80

See also: https://3v4l.org/AKBBH