### PR TITLE
[BUGFIX] Avoid PHP8 errors in backend module

### DIFF
--- a/Classes/Controller/BackendModuleController.php
+++ b/Classes/Controller/BackendModuleController.php
@@ -296,7 +296,8 @@ class BackendModuleController extends AbstractBackendModuleController
         $days = 30;
         $data = $this->getSearchwordStatistics($this->id, $days);
 
-        if ($data['error']) {
+        $error = null;
+        if ($data['error'] ?? false) {
             $error = $data['error'];
             unset($data['error']);
         }


### PR DESCRIPTION
The following errors are fixed in backend module using "Searchword statistics":

    PHP Warning: Undefined array key "error" in /var/www/html/public/typo3conf/ext/ke_search/Classes/Controller/BackendModuleController.php line 299
    PHP Warning: Undefined variable $error in /var/www/html/public/typo3conf/ext/ke_search/Classes/Controller/BackendModuleController.php line 306