### PR TITLE
[TASK] Remove outdated doktypes

### DIFF
--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -36,6 +36,7 @@ use Exception;
 use Tpwd\KeSearch\Indexer\IndexerBase;
 use Tpwd\KeSearch\Lib\SearchHelper;
 use Tpwd\KeSearch\Lib\Db;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository as CorePageRepository;
 use TYPO3\CMS\Core\Html\RteHtmlParser;
 use TYPO3\CMS\Core\LinkHandling\LinkService;
 use TYPO3\CMS\Core\Resource\FileReference;
@@ -105,19 +106,10 @@ class Page extends IndexerBase
     /**
      * this array contains the definition of which page
      * types (field doktype in pages table) should be indexed.
-     * Standard = 1
-     * Advanced = 2
-     * External URL = 3
-     * Shortcut = 4
-     * Not in menu = 5
-     * Backend User Section = 6
-     * Mountpoint = 7
-     * Spacer = 199
-     * SysFolder = 254
-     * Recycler = 255
      * @var array
+     * @see https://github.com/TYPO3/typo3/blob/10.4/typo3/sysext/core/Classes/Domain/Repository/PageRepository.php#L106
      */
-    public $indexDokTypes = array(1, 2, 5);
+    public $indexDokTypes = array(CorePageRepository::DOKTYPE_DEFAULT);
 
     /*
      * Name of indexed elements. Will be overwritten in content element indexer.

--- a/Configuration/TCA/tx_kesearch_indexerconfig.php
+++ b/Configuration/TCA/tx_kesearch_indexerconfig.php
@@ -287,7 +287,7 @@ return array(
             'config' => array(
                 'type' => 'input',
                 'size' => '30',
-                'default' => '1,2,5'
+                'default' => (string)\TYPO3\CMS\Core\Domain\Repository\PageRepository::DOKTYPE_DEFAULT
             )
         ),
         'filteroption' => array(

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -304,8 +304,8 @@
 				<target>Schlagworte auch für Dateien übernehmen?</target>
 			</trans-unit>
 			<trans-unit id="tx_kesearch_indexerconfig.index_page_doctypes" resname="tx_kesearch_indexerconfig.index_page_doctypes"  approved="yes">
-				<source>Page types which should be indexed (field:doktype, default: 1,2,5)</source>
-				<target>Seitentypen, die indexiert werden sollen (Feld:doktype, Standard: 1,2,5)</target>
+				<source>Page types which should be indexed (field:doktype, default: 1)</source>
+				<target>Seitentypen, die indexiert werden sollen (Feld:doktype, Standard: 1)</target>
 			</trans-unit>
 			<trans-unit id="tx_kesearch_indexerconfig.directories" resname="tx_kesearch_indexerconfig.directories"  approved="yes">
 				<source>Directories</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -229,7 +229,7 @@
 				<source>Add tags to files also?</source>
 			</trans-unit>
 			<trans-unit id="tx_kesearch_indexerconfig.index_page_doctypes" resname="tx_kesearch_indexerconfig.index_page_doctypes" >
-				<source>Page types which should be indexed (field:doktype, default: 1,2,5)</source>
+				<source>Page types which should be indexed (field:doktype, default: 1)</source>
 			</trans-unit>
 			<trans-unit id="tx_kesearch_indexerconfig.directories" resname="tx_kesearch_indexerconfig.directories" >
 				<source>Directories</source>

--- a/Resources/Private/Language/nl.locallang_db.xlf
+++ b/Resources/Private/Language/nl.locallang_db.xlf
@@ -300,7 +300,7 @@
 				<target/>
 			</trans-unit>
 			<trans-unit id="tx_kesearch_indexerconfig.index_page_doctypes" resname="tx_kesearch_indexerconfig.index_page_doctypes"  approved="yes">
-				<source>Page types which should be indexed (field:doktype, default: 1,2,5)</source>
+				<source>Page types which should be indexed (field:doktype, default: 1)</source>
 				<target/>
 			</trans-unit>
 			<trans-unit id="tx_kesearch_indexerconfig.directories" resname="tx_kesearch_indexerconfig.directories"  approved="yes">


### PR DESCRIPTION
Doktypes 2 and 5 are not available anymore in recent LTS versions, so they
should be dropped.

See: https://github.com/TYPO3/typo3/blob/10.4/typo3/sysext/core/Classes/Domain/Repository/PageRepository.php#L106