### PR TITLE
[TASK] Add .gitattributes files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/Tests/ export-ignore


### PR DESCRIPTION
"export-ignore" means basically that the are ignored when installing
an extension version via composer. These files aren't necessary on
production systems.

See: https://git-scm.com/docs/gitattributes#_creating_an_archive