### PR TITLE
[DOCS] Revise "Translating filter" section

### DIFF
--- a/Documentation/Configuration/Sorting.rst
+++ b/Documentation/Configuration/Sorting.rst
@@ -8,7 +8,7 @@
 Sorting
 =======
 
-You may define the sorting method in the plugin configuration. Available options are “relevance”, “titel” and “date”.
+You may define the sorting method in the plugin configuration. Available options are “relevance”, “title” and “date”.
 More options may be added through third party extensions (see below “adding your own sorting options”).
 
 There are two sorting method options, one if a searchword was given and one if only filters have been used without

--- a/Documentation/Multilingual/Index.rst
+++ b/Documentation/Multilingual/Index.rst
@@ -31,9 +31,8 @@ In order to use the multilingual feature for filters you'll have to
 
 Create page translations
 	Create alternative page languages for the storage folder where the index and filters are stored and
-	for your search result page. You can do that with help of the list module you by creating a new record called
-	"Alternative Page language" or with the page module by using the function "Make new translation of this page".
+	for your search result page. You can do that with help of the page module by using the function
+    "Create a new translation of this page".
 
 Translate filters and filter options
-    Now you can translate the filters and filteroptions to the new language. Note: In TYPO3 version 9 and below you will
-    have to activate “Localization view”-Checkbox in list module.
+    Now you can translate the filters and filteroptions to the new language.


### PR DESCRIPTION
The "alternative page language" record is gone in TYPO3 v10. The note for
TYPO3 v9 is dropped.

Additionally, a typo on "Sorting" page was fixed.