### PR TITLE
[BUGFIX] Add fallback when label in TCA is not defined

### DIFF
--- a/Classes/Backend/Flexform.php
+++ b/Classes/Backend/Flexform.php
@@ -31,7 +31,7 @@ class Flexform
         foreach($res as $col) {
             $isInList = GeneralUtility::inList($this->notAllowedFields, $col['Field']);
             if (!$isInList) {
-                $file = $GLOBALS['TCA']['tx_kesearch_index']['columns'][$col['Field']]['label'];
+                $file = $GLOBALS['TCA']['tx_kesearch_index']['columns'][$col['Field']]['label'] ?? $col['Field'];
                 $fieldLabel = $this->lang->sL($file);
                 $config['items'][] = array($fieldLabel, $col['Field']);
             }
@@ -54,7 +54,7 @@ class Flexform
         foreach($res as $col) {
             $isInList = GeneralUtility::inList($this->notAllowedFields, $col['Field']);
             if (!$isInList) {
-                $file = $GLOBALS['TCA']['tx_kesearch_index']['columns'][$col['Field']]['label'];
+                $file = $GLOBALS['TCA']['tx_kesearch_index']['columns'][$col['Field']]['label'] ?? $col['Field'];
                 $fieldLabel = $this->lang->sL($file);
                 $config['items'][] = array($fieldLabel . ' UP', $col['Field'] . ' asc');
                 $config['items'][] = array($fieldLabel . ' DOWN', $col['Field'] . ' desc');


### PR DESCRIPTION
Defining an additional field without adding according TCA throws the following errors
for PHP8 when editing the plugin for searchbox and filters (pi1):

    An error occurred trying to process items for field "Sorting for searchresults" (PHP Warning: Undefined array key "my_additional_field" in /var/www/html/public/typo3conf/ext/ke_search/Classes/Backend/Flexform.php line 57).
    An error occurred trying to process items for field "Sorting for searchresults if no searchword/filter is given" (PHP Warning: Undefined array key "my_additional_field" in /var/www/html/public/typo3conf/ext/ke_search/Classes/Backend/Flexform.php line 57).
    An error occurred trying to process items for field "Fields the website user should be able to order by" (PHP Warning: Undefined array key "my_additional_field" in /var/www/html/public/typo3conf/ext/ke_search/Classes/Backend/Flexform.php line 34).

As a fallback, the name of the field is used now.