### PR TITLE
[BUGFIX] Avoid undefined array key when filter options availability is not checked

### DIFF
--- a/Classes/Lib/Pluginbase.php
+++ b/Classes/Lib/Pluginbase.php
@@ -481,7 +481,7 @@ class Pluginbase extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
                     foreach ($options as $optionInResultList) {
                         if ($optionInResultList['value'] == $data['tag']) {
                             $isOptionInOptionArray = true;
-                            $data['results'] = $optionInResultList['results'];
+                            $data['results'] = $optionInResultList['results'] ?? 0;
                             break;
                         }
                     }


### PR DESCRIPTION
The patch fixes an exception in frontend when "Availability check for filter options" in plugin
flexform is set to "no check":

    PHP Warning: Undefined array key "results" in /var/www/html/public/typo3conf/ext/ke_search/Classes/Lib/Pluginbase.php line 484