### PR TITLE
[TASK] Use "extension configuration" over "extension manager configuration"

### DIFF
--- a/Classes/Indexer/Filetypes/Doc.php
+++ b/Classes/Indexer/Filetypes/Doc.php
@@ -72,7 +72,7 @@ class Doc extends File implements FileIndexerInterface
 
         if (!$this->isAppArraySet) {
             $errorMessage = 'The path to catdoctools is not correctly set in the '
-                . 'extension manager configuration. You can get the path with "which catdoc".';
+                . 'extension configuration. You can get the path with "which catdoc".';
             $pObj->logger->error($errorMessage);
             $this->addError($errorMessage);
         }

--- a/Classes/Indexer/Filetypes/Pdf.php
+++ b/Classes/Indexer/Filetypes/Pdf.php
@@ -82,7 +82,7 @@ class Pdf extends File implements FileIndexerInterface
 
         if (!$this->isAppArraySet) {
             $errorMessage = 'The path to pdftools is not correctly set in the '
-                . 'extension manager configuration. You can get the path with "which pdfinfo" or "which pdftotext".';
+                . 'extension configuration. You can get the path with "which pdfinfo" or "which pdftotext".';
             $pObj->logger->error($errorMessage);
             $this->addError($errorMessage);
         }

--- a/Classes/Indexer/Filetypes/Ppt.php
+++ b/Classes/Indexer/Filetypes/Ppt.php
@@ -71,7 +71,7 @@ class Ppt extends File implements FileIndexerInterface
 
         if (!$this->isAppArraySet) {
             $errorMessage = 'The path to catppttools is not correctly set in '
-                . 'extension manager configuration. You can get the path with "which catppt".';
+                . 'extension configuration. You can get the path with "which catppt".';
             $pObj->logger->error($errorMessage);
             $this->addError($errorMessage);
         }

--- a/Classes/Lib/SearchHelper.php
+++ b/Classes/Lib/SearchHelper.php
@@ -47,7 +47,7 @@ class SearchHelper
     public static $systemCategoryPrefix = 'syscat';
 
     /**
-     * get extension manager configuration for ke_search
+     * get extension configuration for ke_search
      * and make it possible to override it with page ts setup
      * @return array
      * @throws ExtensionConfigurationExtensionNotConfiguredException
@@ -86,7 +86,7 @@ class SearchHelper
     }
 
     /**
-     * get extension manager configuration for ke_search_premium
+     * get extension configuration for ke_search_premium
      * and make it possible to override it with page ts setup
      * @return array
      * @throws ExtensionConfigurationExtensionNotConfiguredException

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -6,7 +6,7 @@
 Configuration
 =============
 
-The extension can be configured via the plugin settings (flexform), TypoScript and the extension manager settings.
+The extension can be configured via the plugin settings (flexform), TypoScript and the extension configuration.
 
 .. toctree::
 	:maxdepth: 3

--- a/Documentation/Configuration/Notes.rst
+++ b/Documentation/Configuration/Notes.rst
@@ -25,10 +25,11 @@ or you can define the result page with help of an URL param if you want:
 
    plugin.tx_kesearch_pi1.resultPage.data = GP:tx_kesearch_pi1|resultPage
 
-Notes on TypoScript and extension manager settings
-==================================================
+Notes on TypoScript and extension configuration
+===============================================
 
-In the extension manager you can define basic options like the minimal length of searchwords.
+In :guilabel:`Admin Tools` > :guilabel:`Settings` > :guilabel:`Extension Configuration` you can define basic options
+like the minimal length of searchwords.
 
 You can overwrite this configuration in your page TypoScript setup:
 

--- a/Documentation/Indexing/IndexerTypes/Files.rst
+++ b/Documentation/Indexing/IndexerTypes/Files.rst
@@ -27,7 +27,7 @@ System requirements
 * For PPT indexing you will need to have the external tool "catppt" installed (in Ubuntu Linux it comes
   with the package "catdoc").
 
-Please use the extension manager settings to tell ke_search the file paths where to find these tools.
+Please use the extension configuration to tell ke_search the file paths where to find these tools.
 
 Directory based file indexer with FAL support
 =============================================

--- a/Documentation/Logging/Index.rst
+++ b/Documentation/Logging/Index.rst
@@ -23,9 +23,9 @@ Log messages matching the configured minimum log level are written into a separa
 	============================
 	= Indexing process started =
 	============================
-	Thu, 20 Dec 2018 14:12:21 +0100 [ERROR] request="d40b2d51fe977" component="Tpwd.KeSearch.Indexer.IndexerRunner": The path to catdoctools is not correctly set in the extension manager configuration. You can get the path with "which catdoc".
+	Thu, 20 Dec 2018 14:12:21 +0100 [ERROR] request="d40b2d51fe977" component="Tpwd.KeSearch.Indexer.IndexerRunner": The path to catdoctools is not correctly set in the extension configuration. You can get the path with "which catdoc".
 	Thu, 20 Dec 2018 14:12:21 +0100 [ERROR] request="d40b2d51fe977" component="Tpwd.KeSearch.Indexer.IndexerRunner": The path for xls2csv is not correctly set in extConf. You can get the path with "which xls2csv".
-	Thu, 20 Dec 2018 14:12:21 +0100 [ERROR] request="d40b2d51fe977" component="Tpwd.KeSearch.Indexer.IndexerRunner": The path to catppttools is not correctly set in extension manager configuration. You can get the path with "which catppt".
+	Thu, 20 Dec 2018 14:12:21 +0100 [ERROR] request="d40b2d51fe977" component="Tpwd.KeSearch.Indexer.IndexerRunner": The path to catppttools is not correctly set in extension configuration. You can get the path with "which catppt".
 	Thu, 20 Dec 2018 14:12:21 +0100 [WARNING] request="d40b2d51fe977" component="Tpwd.KeSearch.Indexer.IndexerRunner": Could not index file /var/www/html/web/fileadmin/test/test-invalid.xlsx.
 	Thu, 20 Dec 2018 14:12:21 +0100 [WARNING] request="d40b2d51fe977" component="Tpwd.KeSearch.Indexer.IndexerRunner": Could not index file /var/www/html/web/fileadmin/test/test-invalid.docx.
 	Thu, 20 Dec 2018 14:12:21 +0100 [WARNING] request="d40b2d51fe977" component="Tpwd.KeSearch.Indexer.IndexerRunner": Could not index file /var/www/html/web/fileadmin/test/test-invalid.pptx.


### PR DESCRIPTION
The configuration is not available anymore in the extension manager in recent
TYPO3 versions.