### PR TITLE
[TASK] Simplify determining of log level in ext_localconf.php

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -51,11 +51,10 @@ defined('TYPO3') or die();
     $extConf = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
         \TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class
     )->get('ke_search');
-    $loglevel = !empty($extConf['loglevel']) ? $extConf['loglevel'] : 'ERROR';
-    $loglevel = strtolower($loglevel);
+    $loglevel = strtolower($extConf['loglevel'] ?? 'ERROR');
     $GLOBALS['TYPO3_CONF_VARS']['LOG']['Tpwd']['KeSearch']['writerConfiguration'] = [
         $loglevel => [
-            'TYPO3\\CMS\\Core\\Log\\Writer\\FileWriter' => [
+            \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
                 'logFileInfix' => 'kesearch'
             ]
         ]


### PR DESCRIPTION
The new syntax is slightly different over the previous one: If loglevel is an empty
string, this is now okay. But as the loglevel is a select box in the
extension configuration without an empty value, this is neglectable.

Additionally, use ::class instead of string for FileWriter class.