### PR TITLE
[BUGFIX] Avoid typo3conf path when including backend CSS file

### DIFF
--- a/Resources/Private/Layouts/Backend/Alert.html
+++ b/Resources/Private/Layouts/Backend/Alert.html
@@ -1,4 +1,4 @@
-<f:be.container includeCssFiles="{0: '../typo3conf/ext/ke_search/Resources/Public/Css/backendModule.css'}">
+<f:be.container includeCssFiles="{0: '{f:uri.resource(path:\'Css/backendModule.css\')}'}">
     <div class="typo3-fullDoc">
         <div id="typo3-docheader">
             <div class="typo3-docheader-functions">


### PR DESCRIPTION
This ensures that the stylesheet can be loaded correctly when using
typo3/cms-composer-installers v4.

See: https://b13.com/core-insights/typo3-and-composer-weve-come-a-long-way