### PR TITLE
Add PHP version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "issues": "https://github.com/tpwd/ke_search/issues"
   },
   "require": {
-    "php": "^7.4",
+    "php": "^7.4 || ^8.0",
     "ext-pdo": "*",
     "typo3/cms-core": "^10.4.11 || ^11.0",
     "symfony/polyfill-php80": "^1.23"

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "issues": "https://github.com/tpwd/ke_search/issues"
   },
   "require": {
+    "php": "^7.4",
     "ext-pdo": "*",
     "typo3/cms-core": "^10.4.11 || ^11.0",
     "symfony/polyfill-php80": "^1.23"


### PR DESCRIPTION
Compat with older PHP versions than 7.4 was restored once before (https://github.com/tpwd/ke_search/pull/5) but implicitly dropped again in the meantime (https://github.com/tpwd/ke_search/commit/3b3360ea1d52cb0f827dffd0aaf67527b7bbd77c)

Thus the minimum required PHP version must be stated explicitly.