### PR TITLE
Get file sortdates from the file instead of the file system 

### DIFF
--- a/Classes/Indexer/Types/File.php
+++ b/Classes/Indexer/Types/File.php
@@ -421,7 +421,7 @@ class File extends IndexerBase
         );
 
         $additionalFields = array(
-            'sortdate' => $this->fileInfo->getModificationTime(),
+            'sortdate' => $file->getModificationTime(),
             'orig_uid' => $orig_uid,
             'orig_pid' => 0,
             'directory' => $this->fileInfo->getAbsolutePath(),


### PR DESCRIPTION
Using the file system modification date is fine to decide what to index. But the file system date is not suitable as the ke_search index sortdate for files. In particular, sortdates should stay the same unless the file content changes. Up to now, however,  the sortdate also would change due to moving servers or even when accidentaly using copy instead of mv to relocate the file from one place to another.