### PR TITLE
[TASK] Clean up ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,39 +1,27 @@
 <?php
 /** @noinspection PhpUndefinedVariableInspection */
-$EM_CONF[$_EXTKEY] = array(
+$EM_CONF[$_EXTKEY] = [
     'title' => 'Faceted Search',
     'description' => 'Faceted fulltext search for TYPO3. Fast, flexible and easy to install and use. Indexes content directly from the databases. Features faceting / filtering, file indexing, images in result lists and respects access restrictions.',
     'category' => 'plugin',
-    'shy' => 0,
     'version' => '4.4.1',
-    'dependencies' => '',
-    'conflicts' => '',
-    'priority' => '',
-    'loadOrder' => '',
-    'module' => '',
     'state' => 'stable',
-    'uploadfolder' => 0,
-    'createDirs' => '',
-    'modify_tables' => '',
-    'clearcacheonload' => 0,
-    'lockType' => '',
+    'clearCacheOnLoad' => 0,
     'author' => 'ke_search Dev Team',
     'author_email' => 'ke_search@tpwd.de',
     'author_company' => 'The People Who Do TPWD GmbH',
-    'CGLcompliance' => '',
-    'CGLcompliance_note' => '',
-    'constraints' => array(
-        'depends' => array(
+    'constraints' => [
+        'depends' => [
+            'php' => '7.4.0-8.9.99',
             'typo3' => '10.4.11-11.5.99',
-        ),
-        'conflicts' => array(),
-        'suggests' => array(
+        ],
+        'conflicts' => [],
+        'suggests' => [
             'dashboard' => '10.4.11-11.5.99',
-        ),
-    ),
-    'suggests' => array(),
-    'autoload' => array(
-        'psr-4' => array('Tpwd\\KeSearch\\' => 'Classes'),
-        'classmap' => array('Classes'),
-    ),
-);
+        ],
+    ],
+    'autoload' => [
+        'psr-4' => ['Tpwd\\KeSearch\\' => 'Classes'],
+        'classmap' => ['Classes'],
+    ],
+];


### PR DESCRIPTION
Only properties are provided now which are described in
https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/ExtensionArchitecture/DeclarationFile/Index.html

Additionally, a constraint for the PHP version was added to meet the constraint in composer.json
and short array syntax is used.