### PR TITLE
Add startingPoints public method to Filter class

### DIFF
--- a/Classes/Lib/Filters.php
+++ b/Classes/Lib/Filters.php
@@ -337,4 +337,14 @@ class Filters
     {
         return $this->tagChar;
     }
+
+     /**
+     * returns the starting points IDs
+     *
+     * @return string
+     */
+    public function getStartingPoints()
+    {
+        return $this->startingPoints;
+    }
 }


### PR DESCRIPTION
This allows the starting points to be accessed via the filter hooks

---

We have a custom filter which needs to know about the starting points (as it needs to get data from the indexers). Currently using the `pid` of the filter but doesn't pick up any additional places uses