### PR TITLE
undefined array key includeFilters in Pluginbase.php

### DIFF
--- a/Classes/Lib/Pluginbase.php
+++ b/Classes/Lib/Pluginbase.php
@@ -718,7 +718,7 @@ class Pluginbase extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
         }
 
         // get filters
-        if ((int)($this->conf['includeFilters']) == 1) {
+        if (isset($this->conf['includeFilters']) && (int)($this->conf['includeFilters']) == 1) {
             $this->renderFilters();
         }
 


### PR DESCRIPTION
TYPO3 11.5.18 and PHP 8.1