### PR TITLE
[TASK] Prevent php warning when using automated tagging.

### DIFF
--- a/Classes/Indexer/IndexerBase.php
+++ b/Classes/Indexer/IndexerBase.php
@@ -292,7 +292,9 @@ class IndexerBase
             }
 
             foreach ($pageList as $uid) {
-                $this->pageRecords[$uid]['tags'] = SearchHelper::addTag($row['tag'], $this->pageRecords[$uid]['tags']);
+                if(isset($this->pageRecords[$uid])) {
+                    $this->pageRecords[$uid]['tags'] = SearchHelper::addTag($row['tag'], $this->pageRecords[$uid]['tags']);
+                }
             }
         }
     }


### PR DESCRIPTION
When using automated tagging with multiple indexers in different page trees a php warning is triggered causing the indexer to fail.

Fixes #135 