### PR TITLE
[BUGFIX] Allow to use 'loadFlexformsFromOtherCE' parameter for TypoScript-instantiated plugins

### DIFF
--- a/Classes/Lib/Pluginbase.php
+++ b/Classes/Lib/Pluginbase.php
@@ -188,6 +188,12 @@ class Pluginbase extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
         // get the configuration of the current plugin
         $flexFormConfiguration = $this->getFlexFormConfiguration();
 
+        // When TypoScript is used to spawn a COA of tx_kesearch_pi1 plugin, the above will be empty (as no plugin container exists)
+        // For this specific case, we use the ->conf[] array and parse its setting.
+        if (empty($flexFormConfiguration['loadFlexformsFromOtherCE']) && !empty($this->conf['loadFlexformsFromOtherCE'])) {
+            $flexFormConfiguration['loadFlexformsFromOtherCE'] = $this->conf['loadFlexformsFromOtherCE'];
+        }
+
         // in the list plugin fetch the FlexForm from the search box plugin, because all the configuration is done there
         if (!empty($flexFormConfiguration['loadFlexformsFromOtherCE'])) {
             $currentFlexFormConfiguration = $flexFormConfiguration;


### PR DESCRIPTION
In reference to #151 we actually found out that the issue was caused by the way we setup the plugin. We instantiate it via:

```
lib.searchformDesktop = COA
lib.searchformDesktop {
  10 < plugin.tx_kesearch_pi1
  10.resultPage = {$pageUids.searchPage}
  10.loadFlexformsFromOtherCE = {$contentUids.searchPluginUid}
  10.view.templateRootPaths.9001 = EXT:fe_dbb/Resources/Private/Templates/KeSearch/HeaderDesktop/
  10.view.partialRootPaths.9001 = EXT:fe_dbb/Resources/Private/Partials/KeSearch/
}
```

and expected the plugin to properly load the flexform from a foreign field.

What seems to happen is that Pluginbase uses this:

```
        // get the configuration of the current plugin
        $flexFormConfiguration = $this->getFlexFormConfiguration();
```

which actually tries to resolve 'pi_flexform' from the current plugin instance. In our case, the FlexForm would need to be loaded from another Content Element, and the UID would be found in the `$this->conf['loadFlexformsFromOtherCE']` key.

In this PR we've added a simply check on that key which then properly merges all configuration keys.

This then properly populates the array that is queried in `Db->getLimit()` and thus will not throw a PHP 8+ exception for a missing array key index check. Said array key will only be populated from the flexform configuration, which otherwise would be an empty array.

I quickly skimmed the issue tracker and maybe issue #142 could also be related to this?

I hope the PR can be of use to the project. Many many thanks for supporting it and all your efforts.

Best regards,
Garvin