### PR TITLE
[TASK] Prevent indexing when File Metadata is missing

### DIFF
--- a/Classes/Domain/Repository/BaseRepository.php
+++ b/Classes/Domain/Repository/BaseRepository.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Tpwd\KeSearch\Domain\Repository;
 
 use PDO;

--- a/Classes/Domain/Repository/ContentRepository.php
+++ b/Classes/Domain/Repository/ContentRepository.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Tpwd\KeSearch\Domain\Repository;
 
 use PDO;

--- a/Classes/Domain/Repository/FileMetaDataRepository.php
+++ b/Classes/Domain/Repository/FileMetaDataRepository.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Tpwd\KeSearch\Domain\Repository;
 
 use Doctrine\DBAL\Driver\Exception;

--- a/Classes/Domain/Repository/FileReferenceRepository.php
+++ b/Classes/Domain/Repository/FileReferenceRepository.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Tpwd\KeSearch\Domain\Repository;
 
 use Doctrine\DBAL\Connection as DoctrineDbalConnection;

--- a/Classes/Domain/Repository/FilterOptionRepository.php
+++ b/Classes/Domain/Repository/FilterOptionRepository.php
@@ -262,7 +262,7 @@ class FilterOptionRepository extends BaseRepository
         $record['uid'] = (int)$connection->lastInsertId($this->tableName);
 
         // Create slug
-        $this->update($record['uid'], ['slug'=> SearchHelper::createFilterOptionSlug($record)]);
+        $this->update($record['uid'], ['slug' => SearchHelper::createFilterOptionSlug($record)]);
 
         // add the new filter option to the filter
         $updateFields = [

--- a/Classes/Domain/Repository/GenericRepository.php
+++ b/Classes/Domain/Repository/GenericRepository.php
@@ -42,7 +42,7 @@ class GenericRepository
     public function findByUidAndType($uid, string $type)
     {
         $uid = (int)$uid;
-        if ($uid<=0) {
+        if ($uid <= 0) {
             return false;
         }
 

--- a/Classes/Domain/Repository/NewsRepository.php
+++ b/Classes/Domain/Repository/NewsRepository.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Tpwd\KeSearch\Domain\Repository;
 
 /***************************************************************

--- a/Classes/Domain/Repository/PageRepository.php
+++ b/Classes/Domain/Repository/PageRepository.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Tpwd\KeSearch\Domain\Repository;
 
 use PDO;

--- a/Classes/Domain/Repository/TtAddressRepository.php
+++ b/Classes/Domain/Repository/TtAddressRepository.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Tpwd\KeSearch\Domain\Repository;
 
 /***************************************************************

--- a/Classes/Domain/Repository/TtNewsRepository.php
+++ b/Classes/Domain/Repository/TtNewsRepository.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Tpwd\KeSearch\Domain\Repository;
 
 /***************************************************************

--- a/Classes/Event/MatchColumnsEvent.php
+++ b/Classes/Event/MatchColumnsEvent.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Tpwd\KeSearch\Event;
 
 class MatchColumnsEvent

--- a/Classes/Event/ModifyFieldValuesBeforeStoringEvent.php
+++ b/Classes/Event/ModifyFieldValuesBeforeStoringEvent.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Tpwd\KeSearch\Event;
 
 class ModifyFieldValuesBeforeStoringEvent

--- a/Classes/Hooks/FilterOptionHook.php
+++ b/Classes/Hooks/FilterOptionHook.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace Tpwd\KeSearch\Hooks;
 
 use Tpwd\KeSearch\Domain\Repository\CategoryRepository;

--- a/Classes/Indexer/IndexerBase.php
+++ b/Classes/Indexer/IndexerBase.php
@@ -50,7 +50,7 @@ class IndexerBase
     public $indexerConfig = []; // current indexer configuration
 
     // string which separates metadata from file content in the index record
-    const METADATASEPARATOR = "\n";
+    public const METADATASEPARATOR = "\n";
 
     /** @var int $fileCounter */
     protected $fileCounter = 0;

--- a/Classes/Indexer/IndexerRunner.php
+++ b/Classes/Indexer/IndexerRunner.php
@@ -307,7 +307,7 @@ class IndexerRunner
      * @param string $message
      * @return string
      */
-    public function renderIndexingReport($searchObj, $message='')
+    public function renderIndexingReport($searchObj, $message = '')
     {
         $content = '<tr>';
 

--- a/Classes/Indexer/Types/News.php
+++ b/Classes/Indexer/Types/News.php
@@ -370,19 +370,19 @@ class News extends IndexerBase
         return $message;
     }
 
-/**
- * checks if there is a category assigned to the $newsRecord which has
-     * its own single view page and if yes, returns the uid of the page
-     * in $catagoryData['single_pid'].
-     * It also compiles a list of all assigned categories and returns
-     * it as an array in $categoryData['uid_list']. The titles of the
-     * categories are returned in $categoryData['title_list'] (array)
-     *
-     * @author Christian Bülter
-     * @since 26.06.13 14:34
-     * @param array $newsRecord
-     * @return array
-     */
+    /**
+     * checks if there is a category assigned to the $newsRecord which has
+         * its own single view page and if yes, returns the uid of the page
+         * in $catagoryData['single_pid'].
+         * It also compiles a list of all assigned categories and returns
+         * it as an array in $categoryData['uid_list']. The titles of the
+         * categories are returned in $categoryData['title_list'] (array)
+         *
+         * @author Christian Bülter
+         * @since 26.06.13 14:34
+         * @param array $newsRecord
+         * @return array
+         */
     private function getCategoryData($newsRecord)
     {
         /** @var PageRepository $pageRepository */

--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -1134,6 +1134,28 @@ class Page extends IndexerBase
             $metadata = $fileObject->getMetaData()->get();
         }
 
+        if (empty($metadata)) {
+            if ($fileObject instanceof FileReference) {
+                $errorMessage = sprintf(
+                    'Could not get meta data from file reference [uid:%d], file [uid:%d] (%s).',
+                    $fileObject->getUid(),
+                    $fileObject->getOriginalFile()->getUid(),
+                    $fileObject->getOriginalFile()->getIdentifier()
+                );
+            } else {
+                $errorMessage = sprintf(
+                    'Could not get meta data from file [uid:%d] (%s).',
+                    $fileObject->getUid(),
+                    $fileObject->getIdentifier()
+                );
+            }
+
+            $this->pObj->logger->warning($errorMessage);
+            $this->addError($errorMessage);
+
+            return;
+        }
+
         if (isset($metadata['fe_groups']) && !empty($metadata['fe_groups'])) {
             if ($feGroups) {
                 $feGroupsContentArray = GeneralUtility::intExplode(',', $feGroups);

--- a/Classes/Lib/Db.php
+++ b/Classes/Lib/Db.php
@@ -46,7 +46,7 @@ use TYPO3\CMS\Core\Utility\MathUtility;
  */
 class Db implements SingletonInterface
 {
-    const DEFAULT_MATCH_COLUMS = 'title,content,hidden_content';
+    public const DEFAULT_MATCH_COLUMS = 'title,content,hidden_content';
     public $conf = [];
     public $countResultsOfTags = 0;
     public $countResultsOfContent = 0;

--- a/Classes/Lib/Filters.php
+++ b/Classes/Lib/Filters.php
@@ -348,11 +348,11 @@ class Filters
         return $this->tagChar;
     }
 
-     /**
-     * returns the starting points IDs
-     *
-     * @return string
-     */
+    /**
+    * returns the starting points IDs
+    *
+    * @return string
+    */
     public function getStartingPoints()
     {
         return $this->startingPoints;

--- a/Classes/Lib/Pluginbase.php
+++ b/Classes/Lib/Pluginbase.php
@@ -422,7 +422,7 @@ class Pluginbase extends AbstractPlugin
             }
 
             // build link to reset this filter while keeping the others
-            $resetLink= SearchHelper::searchLink($this->conf['resultPage'], $this->piVars, [$filter['uid']]);
+            $resetLink = SearchHelper::searchLink($this->conf['resultPage'], $this->piVars, [$filter['uid']]);
 
             // set values for fluid template
             $filterData = $filter;

--- a/Classes/Lib/SearchHelper.php
+++ b/Classes/Lib/SearchHelper.php
@@ -154,7 +154,7 @@ class SearchHelper
      * @param string $tags
      * @return string
      */
-    public static function addTag(string $tagToAdd, $tags='')
+    public static function addTag(string $tagToAdd, $tags = '')
     {
         if ($tagToAdd) {
             $extConf = SearchHelper::getExtConf();
@@ -334,7 +334,7 @@ class SearchHelper
      * @param string $linkText
      * @return string
      */
-    public static function searchLink(int $parameter, array $piVars=[], $resetFilters=[], $linkText = ''): string
+    public static function searchLink(int $parameter, array $piVars = [], $resetFilters = [], $linkText = ''): string
     {
         // If no cObj is available we cannot render the link.
         // This might be the case if the current request is headless (ke_search_premium feature).

--- a/Classes/Lib/Sorting.php
+++ b/Classes/Lib/Sorting.php
@@ -193,7 +193,7 @@ class Sorting
      * @param bool $urlOnly
      * @return string
      */
-    public function generateSortingLink(string $field, string $sortByDir, bool $urlOnly=false): string
+    public function generateSortingLink(string $field, string $sortByDir, bool $urlOnly = false): string
     {
         $localPiVars = $this->pObj->piVars;
         $localPiVars['sortByField'] = $field;

--- a/Classes/Routing/Aspect/KeSearchTagToSlugMapper.php
+++ b/Classes/Routing/Aspect/KeSearchTagToSlugMapper.php
@@ -42,7 +42,7 @@ class KeSearchTagToSlugMapper implements StaticMappableAspectInterface
     {
         /** @var Context $context */
         $context = GeneralUtility::makeInstance(Context::class);
-        $languageId =$context->getPropertyFromAspect('language', 'id');
+        $languageId = $context->getPropertyFromAspect('language', 'id');
 
         /** @var ConnectionPool $connectionPool */
         $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
@@ -66,7 +66,7 @@ class KeSearchTagToSlugMapper implements StaticMappableAspectInterface
     {
         /** @var Context $context */
         $context = GeneralUtility::makeInstance(Context::class);
-        $languageId =$context->getPropertyFromAspect('language', 'id');
+        $languageId = $context->getPropertyFromAspect('language', 'id');
 
         /** @var ConnectionPool $connectionPool */
         $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);


### PR DESCRIPTION
When metadata (`sys_file_metadata`) of a file is missing, an error will occur while indexing.