### PR TITLE
fix encoding  of spaces in file path

### DIFF
--- a/Classes/Lib/SearchHelper.php
+++ b/Classes/Lib/SearchHelper.php
@@ -251,7 +251,7 @@ class SearchHelper
                 } else {
                     if (file_exists($resultRow['directory'] . $resultRow['title'])) {
                         $linkConf['parameter'] =
-                            PathUtility::stripPathSitePrefix($resultRow['directory'])
+                            PathUtility::stripPathSitePrefix(implode('/', array_map('rawurlencode', explode('/', $resultRow['directory']))))
                             . rawurlencode($resultRow['title']);
                     }
                 }


### PR DESCRIPTION
After #146, only the file name is rawurlencoded, not the path. Subsequently, spaces in directory names are not encoded as `%20`, leading to spaces in the `linkConf`, which cuts the `href`attribute after the first space.

As rawurlencoding the complete path results in escaped slashes,  the path segments should be encoded individually.