### PR TITLE
[BUGFIX] Pass $field to modifyContentFromContentElement hook

### DIFF
--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -1281,7 +1281,8 @@ class Page extends IndexerBase
                 $_procObj->modifyContentFromContentElement(
                     $content,
                     $ttContentRow,
-                    $this
+                    $this,
+                    $field
                 );
             }
         }


### PR DESCRIPTION
I added $field to the modifyContentFromContentElement hook, because the hook is executed for each entry from tx_kesearch_indexerconfig.content_fields.

This causes problems when modifying/extending the $bodytext because the modification will be done as many times as there are additional fields in the content_fields column of the tx_kesearch_indexerconfig table.

Passing the $field variable to the hook enables us to only executing the hook for a given field.

The change is backwards compatible since php just ignores arguments which are not present in the method signature.