### PR TITLE
[TASK] Properly type-hint IndexerBase constructor

### DIFF
--- a/Classes/Indexer/IndexerBase.php
+++ b/Classes/Indexer/IndexerBase.php
@@ -25,7 +25,6 @@ use Tpwd\KeSearch\Indexer\Types\File;
 use Tpwd\KeSearch\Lib\Db;
 use Tpwd\KeSearch\Lib\SearchHelper;
 use Tpwd\KeSearch\Service\FileService;
-use Tpwd\KeSearch\Indexer\IndexerRunner;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryHelper;

--- a/Classes/Indexer/IndexerBase.php
+++ b/Classes/Indexer/IndexerBase.php
@@ -25,6 +25,7 @@ use Tpwd\KeSearch\Indexer\Types\File;
 use Tpwd\KeSearch\Lib\Db;
 use Tpwd\KeSearch\Lib\SearchHelper;
 use Tpwd\KeSearch\Service\FileService;
+use Tpwd\KeSearch\Indexer\IndexerRunner;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryHelper;
@@ -82,9 +83,9 @@ class IndexerBase
 
     /**
      * Constructor of this object
-     * @param $pObj
+     * @param IndexerRunner $pObj
      */
-    public function __construct($pObj)
+    public function __construct(IndexerRunner $pObj)
     {
         $this->startMicrotime = microtime(true);
         $this->pObj = $pObj;


### PR DESCRIPTION
The class IndexerBase is missing type-hint on its constructor argument. This prevents us from using dependency injection in the consuming custom indexers. 