### PR TITLE
TYPO3 v12: Add "ignorePageTypeRestriction" to TCA configs

### DIFF
--- a/Configuration/TCA/tx_kesearch_filteroptions.php
+++ b/Configuration/TCA/tx_kesearch_filteroptions.php
@@ -35,6 +35,9 @@ $txKesearchFilteroptionsTCA = [
         'enablecolumns' => [
             'disabled' => 'hidden',
         ],
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
         'iconfile' => 'EXT:ke_search/Resources/Public/Icons/table_icons/icon_tx_kesearch_filteroptions.gif',
         'searchFields' => 'title,tag,slug',
     ],

--- a/Configuration/TCA/tx_kesearch_filters.php
+++ b/Configuration/TCA/tx_kesearch_filters.php
@@ -74,6 +74,9 @@ $txKesearchFiltersTCA = [
         'enablecolumns' => [
             'disabled' => 'hidden',
         ],
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
         'iconfile' => 'EXT:ke_search/Resources/Public/Icons/table_icons/icon_tx_kesearch_filters.gif',
         'searchFields' => 'title',
     ],

--- a/Configuration/TCA/tx_kesearch_index.php
+++ b/Configuration/TCA/tx_kesearch_index.php
@@ -96,6 +96,9 @@ $txKesearchIndex = [
             'endtime' => 'endtime',
             'fe_group' => 'fe_group',
         ],
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
         'iconfile' => 'EXT:ke_search/Resources/Public/Icons/table_icons/icon_tx_kesearch_index.gif',
     ],
     'columns' => [

--- a/Configuration/TCA/tx_kesearch_indexerconfig.php
+++ b/Configuration/TCA/tx_kesearch_indexerconfig.php
@@ -198,6 +198,9 @@ $txKesearchIndexerconfig = [
         'enablecolumns' => [
             'disabled' => 'hidden',
         ],
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
         'iconfile' => 'EXT:ke_search/Resources/Public/Icons/table_icons/icon_tx_kesearch_indexerconfig.gif',
         'searchFields' => 'title',
     ],


### PR DESCRIPTION
Without this settings you cannot see nor add new configs via list module. Required for TYPO3 v12.