### PR TITLE
PHP Warning: Undefined array key "alternative" (and "description")

### DIFF
--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -1186,7 +1186,7 @@ class Page extends IndexerBase
             $content = $metadata['description'] . "\n" . $content;
         }
 
-        if ($metadata['alternative']) {
+        if ($metadata['alternative'] ?? null) {
             $content .= "\n" . $metadata['alternative'];
         }
 

--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -1181,7 +1181,7 @@ class Page extends IndexerBase
         }
 
         $abstract = '';
-        if ($metadata['description']) {
+        if ($metadata['description'] ?? null) {
             $abstract = $metadata['description'];
             $content = $metadata['description'] . "\n" . $content;
         }


### PR DESCRIPTION
TYPO3 11.5.36
ke_search 5.2.1
PHP 8.2.15

Manually starting the Indexer failed in the BE.

`Core: Exception handler (WEB): Uncaught TYPO3 Exception: #1476107295: PHP Warning: Undefined array key "alternative" in /var/www/typo3/public/typo3conf/ext/ke_search/Classes/Indexer/Types/Page.php line 1189 | TYPO3\CMS\Core\Error\Exception thrown in file /var/www/typo3/public/typo3/sysext/core/Classes/Error/ErrorHandler.php in line 137. Requested URL: https://my.domain.tld/typo3/module/web/KeSearchBackendModule?token=--AnonymizedToken--&id=217&do=startindexer `

or

`Core: Exception handler (WEB): Uncaught TYPO3 Exception: #1476107295: PHP Warning: Undefined array key "description" in /var/www/typo3/public/typo3conf/ext/ke_search/Classes/Indexer/Types/Page.php line 1184 | TYPO3\CMS\Core\Error\Exception thrown in file /var/www/typo3/public/typo3/sysext/core/Classes/Error/ErrorHandler.php in line 137. Requested URL: https://my.domain.tld/typo3/module/web/KeSearchBackendModule?token=--AnonymizedToken--&id=217&do=startindexer`


This change resolved the issue.

Maybe the following line has to be changed as well?

Line 1179:
`if ($metadata['title'] ?? null) {`