### PR TITLE
Remove records in incremental mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ ChangeLog
 
 Version 5.5.0, 17 May 2024
 [FEATURE] Add pagination in the backend module "Indexed content" function and avoid out of memory error. https://github.com/tpwd/ke_search/issues/100
+[FEATURE] Remove obsolete records during incremental indexing. Records and files which should not be indexed (e.g. pages with "no_index" flag) are now removed from the index during incremental indexing. Previously only hidden and deleted pages, records and files were removed.
 [BUGFIX]  Render file preview in result list only for files which are in the "imagefile_ext" list (images and PDF files). https://github.com/tpwd/ke_search/issues/60
 [BUGFIX]  Don't stop indexing if a folder does not exist. Thanks to Philip Hartmann. https://github.com/tpwd/ke_search/issues/225
 [TASK]    Add BEGIN and COMMIT statements needed to run ke_search in a Percona-Database-Cluster with strict-mode. Thanks to rentz-skygate. https://github.com/tpwd/ke_search/issues/222

--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -206,13 +206,15 @@ class IndexRepository
                 } else {
                     $origUid = $record['uid'];
                 }
-                $this->deleteByUniqueProperties(
+                $numberOfAffectedRows = $this->deleteByUniqueProperties(
                     $origUid,
                     $indexerConfig['storagepid'],
                     $type,
                     $record['sys_language_uid']
                 );
-                $count++;
+                if ($numberOfAffectedRows) {
+                    $count += $numberOfAffectedRows;
+                }
             }
         }
         return $count;

--- a/Classes/Indexer/IndexerBase.php
+++ b/Classes/Indexer/IndexerBase.php
@@ -21,9 +21,11 @@ namespace Tpwd\KeSearch\Indexer;
  ***************************************************************/
 
 use PDO;
+use Tpwd\KeSearch\Domain\Repository\IndexRepository;
 use Tpwd\KeSearch\Indexer\Types\File;
 use Tpwd\KeSearch\Lib\Db;
 use Tpwd\KeSearch\Lib\SearchHelper;
+use Tpwd\KeSearch\Service\IndexerStatusService;
 use Tpwd\KeSearch\Utility\FileUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -32,6 +34,8 @@ use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Resource\FileRepository;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -88,6 +92,9 @@ class IndexerBase
      */
     protected $indexingMode = self::INDEXING_MODE_FULL;
 
+    protected IndexerStatusService $indexerStatusService;
+    protected IndexRepository $indexRepository;
+
     /**
      * Constructor of this object
      * @param IndexerRunner $pObj
@@ -98,6 +105,8 @@ class IndexerBase
         $this->pObj = $pObj;
         $this->indexerConfig = $this->pObj->indexerConfig;
         $this->lastRunStartTime = SearchHelper::getIndexerLastRunTime();
+        $this->indexerStatusService = GeneralUtility::makeInstance(IndexerStatusService::class);
+        $this->indexRepository = GeneralUtility::makeInstance(IndexRepository::class);
     }
 
     /**
@@ -738,5 +747,89 @@ class IndexerBase
             }
         }
         return $theList;
+    }
+
+    /**
+     * Removes a row from the index which corresponds to the given $record.
+     * $record must contain at least the fields 'uid', 'pid' and 'sys_language_uid'.
+     *
+     * @param string $type
+     * @param array $record
+     */
+    public function removeRecordFromIndex(string $type, array $record)
+    {
+        $numberOfAffectedRows = $this->indexRepository->deleteCorrespondingIndexRecords(
+            $type,
+            [$record],
+            $this->indexerConfig
+        );
+        if ($numberOfAffectedRows > 0) {
+            $this->counterRemoved += $numberOfAffectedRows;
+            $this->pObj->logger->debug('Removed ' . $numberOfAffectedRows . ' corresponding index records', $record);
+        }
+    }
+
+    /**
+     * Removes a file from the index.
+     *
+     * @param \TYPO3\CMS\Core\Resource\File $file
+     */
+    public function removeFileFromIndex(\TYPO3\CMS\Core\Resource\File $file)
+    {
+        $orig_uid = $file->getUid();
+        $pid = $this->indexerConfig['storagepid'];
+        $language = $this->detectFileLanguage($file->getProperties());
+        $type = 'file:' . $file->getExtension();
+        $numberOfAffectedRows = $this->indexRepository->deleteByUniqueProperties($orig_uid, $pid, $type, $language);
+        $numberOfAffectedRows = (int)$numberOfAffectedRows;
+        if ($numberOfAffectedRows > 0) {
+            $this->counterRemoved += $numberOfAffectedRows;
+            $this->pObj->logger->debug(
+                'Removed ' . $numberOfAffectedRows . ' index records for file "' . $file->getCombinedIdentifier() . '"',
+                [
+                    'orig_uid' => $orig_uid,
+                    'pid' => $pid,
+                    'type' => $type,
+                    'language' => $language,
+                ]
+            );
+        }
+    }
+
+    /**
+     * Tries to detect the language of file from metadata field 'language' and returns the language_uid.
+     * The field 'language' comes with the optional extension 'filemetadata'.
+     * Returns -1 ("all languages") language could not be determined.
+     *
+     * @param array $fileProperties
+     * @return int
+     */
+    protected function detectFileLanguage(array $fileProperties): int
+    {
+        $sites = GeneralUtility::makeInstance(SiteFinder::class)->getAllSites();
+        $languages = [];
+        /** @var Site $site */
+        foreach ($sites as $site) {
+            $siteLanguages = $site->getLanguages();
+            foreach ($siteLanguages as $siteLanguageId => $siteLanguage) {
+                $languages[strtolower($siteLanguage->getLocale())] = $siteLanguageId;
+                if ($siteLanguage->getTitle()) {
+                    $languages[strtolower($siteLanguage->getTitle())] = $siteLanguageId;
+                }
+                if ($siteLanguage->getHreflang()) {
+                    $languages[strtolower($siteLanguage->getHreflang())] = $siteLanguageId;
+                }
+                if ($siteLanguage->getTwoLetterIsoCode()) {
+                    $languages[strtolower($siteLanguage->getTwoLetterIsoCode())] = $siteLanguageId;
+                }
+            }
+        }
+
+        if (isset($fileProperties['language']) && array_key_exists($fileProperties['language'], $languages)) {
+            $languageUid = $languages[$fileProperties['language']];
+        } else {
+            $languageUid = -1;
+        }
+        return $languageUid;
     }
 }

--- a/Classes/Indexer/IndexerBase.php
+++ b/Classes/Indexer/IndexerBase.php
@@ -52,8 +52,16 @@ class IndexerBase
     // string which separates metadata from file content in the index record
     public const METADATASEPARATOR = "\n";
 
-    /** @var int $fileCounter */
+    /**
+     * counter for how many files we have indexed
+     * @var int
+     */
     protected $fileCounter = 0;
+
+    /**
+     * counter for how many records have been removed in incremental mode
+     */
+    protected int $counterRemoved = 0;
 
     /**
      * @var IndexerRunner

--- a/Classes/Indexer/Types/News.php
+++ b/Classes/Indexer/Types/News.php
@@ -164,7 +164,8 @@ class News extends IndexerBase
                 }
 
                 if ($shouldBeIndexed) {
-                    $this->pObj->logger->debug('Indexing news record "' . $newsRecord['title'] . '"',
+                    $this->pObj->logger->debug(
+                        'Indexing news record "' . $newsRecord['title'] . '"',
                         [
                             'uid' => $newsRecord['uid'],
                             'pid' => $newsRecord['pid'],
@@ -172,7 +173,8 @@ class News extends IndexerBase
                         ]
                     );
                 } else {
-                    $this->pObj->logger->debug('Skipping news record "' . $newsRecord['title'] . '"',
+                    $this->pObj->logger->debug(
+                        'Skipping news record "' . $newsRecord['title'] . '"',
                         [
                             'uid' => $newsRecord['uid'],
                             'pid' => $newsRecord['pid'],

--- a/Classes/Indexer/Types/TtAddress.php
+++ b/Classes/Indexer/Types/TtAddress.php
@@ -7,7 +7,6 @@ use Tpwd\KeSearch\Domain\Repository\TtAddressRepository;
 use Tpwd\KeSearch\Indexer\IndexerBase;
 use Tpwd\KeSearch\Lib\Db;
 use Tpwd\KeSearch\Lib\SearchHelper;
-use Tpwd\KeSearch\Service\IndexerStatusService;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -36,15 +35,12 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class TtAddress extends IndexerBase
 {
-    protected IndexerStatusService $indexerStatusService;
-
     /**
      * Initializes indexer for tt_address
      */
     public function __construct($pObj)
     {
         parent::__construct($pObj);
-        $this->indexerStatusService = GeneralUtility::makeInstance(IndexerStatusService::class);
     }
 
     /**

--- a/Classes/Indexer/Types/TtContent.php
+++ b/Classes/Indexer/Types/TtContent.php
@@ -97,15 +97,17 @@ class TtContent extends Page
 
         if (count($rows)) {
             foreach ($rows as $row) {
+                $shouldBeIndexed = true;
+
                 // skip this content element if the page itself is hidden or a
                 // parent page with "extendToSubpages" set is hidden
                 if ($pageAccessRestrictions['hidden']) {
-                    continue;
+                    $shouldBeIndexed = false;
                 }
 
                 // skip this content element if the page is hidden or set to "no_search"
                 if (!$this->checkIfpageShouldBeIndexed($uid, $row['sys_language_uid'])) {
-                    continue;
+                    $shouldBeIndexed = false;
                 }
 
                 // combine group access restrictons from page(s) and content element
@@ -118,6 +120,13 @@ class TtContent extends Page
                 // element is set to "hide at login"
                 // and the other one has a frontend group attached to it
                 if ($feGroups == DONOTINDEX) {
+                    $shouldBeIndexed = false;
+                }
+
+                if (!$shouldBeIndexed) {
+                    if ($this->indexingMode == self::INDEXING_MODE_INCREMENTAL) {
+                        $this->removeRecordFromIndex('content', $row);
+                    }
                     continue;
                 }
 

--- a/Classes/Indexer/Types/TtNews.php
+++ b/Classes/Indexer/Types/TtNews.php
@@ -9,7 +9,6 @@ use Tpwd\KeSearch\Indexer\IndexerBase;
 use Tpwd\KeSearch\Indexer\IndexerRunner;
 use Tpwd\KeSearch\Lib\Db;
 use Tpwd\KeSearch\Lib\SearchHelper;
-use Tpwd\KeSearch\Service\IndexerStatusService;
 use TYPO3\CMS\Core\Resource\FileRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -39,8 +38,6 @@ class TtNews extends IndexerBase
     /** @var int $fileCounter */
     protected $fileCounter = 0;
 
-    protected IndexerStatusService $indexerStatusService;
-
     /**
      * Initializes indexer for tt_news
      *
@@ -51,7 +48,6 @@ class TtNews extends IndexerBase
         parent::__construct($pObj);
         $this->pObj = $pObj;
         $this->fileRepository = GeneralUtility::makeInstance(FileRepository::class);
-        $this->indexerStatusService = GeneralUtility::makeInstance(IndexerStatusService::class);
     }
 
     /**


### PR DESCRIPTION
Some records will be skipped during
full indexing, e.g. page records that have the
"no_index" flag or news records without
required categories. Incremental indexing
currently only removes "deleted" and
"hidden" records but should also remove
records that would be skipped for other
reasons in normal indexing.

During incremental tt_content record which
should not be indexed (e.g. parent page has
"no_search" flag is set) will
now be removed from the index.

During incremental indexing files which
should not be indexed (e.g.
"tx_kesearch_no_search" flag is set) will
now be removed from the index.

Additionally instantiating indexerStatusService
and indexRepository has now been moved to the
IndexerBase class, along with the functions
removeRecordFromIndex, removeFileFromIndex and
detectFileLanguage.