### PR TITLE
[BUGFIX] Respect custom PageTypes while auto-tagging

### DIFF
--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -249,6 +249,10 @@ class Page extends IndexerBase
         // excluded (see: http://forge.typo3.org/issues/49435)
         $where = ' (doktype = 1 OR doktype = 2 OR doktype = 4 OR doktype = 5 OR doktype = 254) ';
 
+        if (!empty($this->indexerConfig['index_page_doctypes'])) {
+            $where = 'doktype in (1,2,4,5,254,' . $this->indexerConfig['index_page_doctypes'] .  ')';
+        }
+        
         // add the tags of each page to the global page array
         $this->addTagsToRecords($indexPids, $where);
 


### PR DESCRIPTION
If index_page_doctypes is set in the Page indexer, the given doctypes were respected while processing the tags using Auto-Tagging.

The Pagetypes 1,2,4,5 and 254 set in the current code are respected in any case (not sure, if this is needed though). 

Fixes: #233 