### PR TITLE
[TASK] Move check if header field should be indexed in separate method

### DIFF
--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -649,7 +649,7 @@ class Page extends IndexerBase
 
                 // index header
                 // add header only if not set to "hidden", do not add header of html element
-                if ($ttContentRow['header_layout'] != 100 && $ttContentRow['CType'] != 'html') {
+                if ($this->contentElementsHeaderShouldBeIndexed($ttContentRow)) {
                     $content .= strip_tags($ttContentRow['header']) . "\n";
                 }
 
@@ -880,6 +880,18 @@ class Page extends IndexerBase
         }
 
         return $contentElementShouldBeIndexed;
+    }
+
+    /**
+     * Checks if the header field of the given row from tt_content should really be indexed 
+     * by checking if header_layout is not hidden and CType is not html.
+     *
+     * @param $ttContentRow
+     * @return bool
+     */
+    public function contentElementsHeaderShouldBeIndexed($ttContentRow)
+    {
+        return $ttContentRow['header_layout'] != 100 && $ttContentRow['CType'] != 'html';
     }
 
     /**

--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -891,7 +891,21 @@ class Page extends IndexerBase
      */
     public function contentElementsHeaderShouldBeIndexed($ttContentRow)
     {
-        return $ttContentRow['header_layout'] != 100 && $ttContentRow['CType'] != 'html';
+        $contentElementsHeaderShouldBeIndexed = $ttContentRow['header_layout'] != 100 && $ttContentRow['CType'] != 'html';
+
+        // hook to add custom check if this content elements header should be indexed
+        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['contentElementsHeaderShouldBeIndexed'] ?? null)) {
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['contentElementsHeaderShouldBeIndexed'] as $_classRef) {
+                $_procObj = GeneralUtility::makeInstance($_classRef);
+                $contentElementsHeaderShouldBeIndexed = $_procObj->contentElementsHeaderShouldBeIndexed(
+                    $ttContentRow,
+                    $contentElementsHeaderShouldBeIndexed,
+                    $this
+                );
+            }
+        }
+
+        return $contentElementsHeaderShouldBeIndexed;
     }
 
     /**

--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -883,7 +883,7 @@ class Page extends IndexerBase
     }
 
     /**
-     * Checks if the header field of the given row from tt_content should really be indexed 
+     * Checks if the header field of the given row from tt_content should really be indexed
      * by checking if header_layout is not hidden and CType is not html.
      *
      * @param $ttContentRow


### PR DESCRIPTION
This PR moves the check for whether a content element's header field should be indexed to a separate method.

I need this change because I'm overriding/extending the page indexer and want to extend this logic. 
We use the header field for some elements as a backend-only field, so it needs to be excluded from the index.

I noticed a TODO comment in the tt_content indexer regarding making this check customizable via a hook. Are there any updates or plans for when this might be implemented?

For now, I would appreciate it if this PR could be merged.

Thank you for your time,
Joost