### PR TITLE
Allow File Collections to be indexed

### DIFF
--- a/Classes/Indexer/Types/File.php
+++ b/Classes/Indexer/Types/File.php
@@ -32,11 +32,13 @@ use Tpwd\KeSearch\Lib\Fileinfo;
 use Tpwd\KeSearch\Lib\SearchHelper;
 use Tpwd\KeSearch\Utility\FileUtility;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Resource\Folder;
 use TYPO3\CMS\Core\Resource\Index\MetaDataRepository;
 use TYPO3\CMS\Core\Resource\ResourceStorage;
 use TYPO3\CMS\Core\Resource\StorageRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Resource\FileCollector;
 
 /**
  * Plugin 'Faceted search' for the 'ke_search' extension.
@@ -95,23 +97,33 @@ class File extends IndexerBase
     {
         $directories = $this->indexerConfig['directories'];
         $directoryArray = GeneralUtility::trimExplode(',', $directories, true);
-        if (empty($directoryArray)) {
-            $errorMessage = 'No directories defined for indexing.';
+
+        $fileCollections = $this->indexerConfig['file_collections'];
+
+        if (empty($directoryArray) && empty($fileCollections)) {
+            $errorMessage = 'No directories or file collections defined for indexing.';
             // @extensionScannerIgnoreLine
             $this->pObj->logger->error($errorMessage);
             $this->addError($errorMessage);
             return $errorMessage;
         }
 
-        if ($this->indexerConfig['fal_storage'] > 0) {
-            /* @var $storageRepository StorageRepository */
-            $storageRepository = GeneralUtility::makeInstance(StorageRepository::class);
-            $this->storage = $storageRepository->findByUid($this->indexerConfig['fal_storage']);
+        $files = [];
+        if (count($directoryArray)) {
+            if ($this->indexerConfig['fal_storage'] > 0) {
+                /* @var $storageRepository StorageRepository */
+                $storageRepository = GeneralUtility::makeInstance(StorageRepository::class);
+                $this->storage = $storageRepository->findByUid($this->indexerConfig['fal_storage']);
 
-            $files = [];
-            $this->getFilesFromFal($files, $directoryArray);
-        } else {
-            $files = $this->getFilesFromDirectories($directoryArray);
+
+                $this->getFilesFromFal($files, $directoryArray);
+            } else {
+                $files = $this->getFilesFromDirectories($directoryArray);
+            }
+        }
+
+        if (!empty($fileCollections)) {
+            $this->getFilesFromFileCollections($files, $fileCollections);
         }
 
         $counter = $this->extractContentAndSaveToIndex($files);
@@ -238,6 +250,27 @@ class File extends IndexerBase
             return $files;
         }
         return [];
+    }
+
+    public function getFilesFromFileCollections(&$files, $fileCollections): void
+    {
+        // Boot up the filecollector
+        $fileCollector = GeneralUtility::makeInstance(FileCollector::class);
+
+        // Extract the IDs of file collections
+        $collectionsArray = GeneralUtility::trimExplode(',', $fileCollections, true);
+
+        // Collect the files associated
+        $fileCollector->addFilesFromFileCollections($collectionsArray);
+
+        // If the file collection "type" is "static" then file references are returned
+        $collectionFiles = array_map(
+            fn ($item) => ($item instanceof FileReference) ? $item->getOriginalFile() : $item,
+            $fileCollector->getFiles()
+        );
+
+        // Get the files & index them
+        $files = array_merge($files, $collectionFiles);
     }
 
     /**

--- a/Configuration/TCA/tx_kesearch_indexerconfig.php
+++ b/Configuration/TCA/tx_kesearch_indexerconfig.php
@@ -264,6 +264,20 @@ $txKesearchIndexerconfig = [
                 'eval' => 'trim',
             ],
         ],
+        'file_collections' => [
+            'label' => 'LLL:EXT:ke_search/Resources/Private/Language/locallang_db.xlf:tx_kesearch_indexerconfig.file_collections',
+            'displayCond' => [
+                'AND' => [
+                    'FIELD:type:IN:file',
+                    'FIELD:fal_storage:!=:0',
+                ],
+            ],
+            'config' => [
+                'type' => 'group',
+                'allowed' => 'sys_file_collection',
+                'size' => 100,
+            ],
+        ],
         'fileext' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:ke_search/Resources/Private/Language/locallang_db.xlf:tx_kesearch_indexerconfig.fileext',
@@ -342,6 +356,7 @@ $txKesearchIndexerconfig = [
             'exclude' => 0,
             'label' => 'LLL:EXT:ke_search/Resources/Private/Language/locallang_db.xlf:tx_kesearch_indexerconfig.fal_storage',
             'displayCond' => 'FIELD:type:=:file',
+            'onChange' => 'reload',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -475,7 +490,7 @@ fields[] = bodytext
                 --div--;LLL:EXT:ke_search/Resources/Private/Language/locallang_db.xlf:tx_kesearch_indexerconfig.tabs.advanced,
             index_content_with_restrictions,
             index_news_archived,index_news_category_mode,index_extnews_category_selection,
-            index_use_page_tags,fal_storage,directories,index_page_doctypes,contenttypes,additional_tables,content_fields,fileext,file_reference_fields,
+            index_use_page_tags,fal_storage,directories,file_collections,index_page_doctypes,contenttypes,additional_tables,content_fields,fileext,file_reference_fields,
             index_news_files_mode,
             filteroption,index_use_page_tags_for_files',
         ],

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -255,6 +255,9 @@
 			<trans-unit id="tx_kesearch_indexerconfig.index_page_doctypes.description" resname="tx_kesearch_indexerconfig.index_page_doctypes.description" >
 				<source>Refers to the field "doktype" in the "pages" table, default: 1</source>
 			</trans-unit>
+			<trans-unit id="tx_kesearch_indexerconfig.file_collections" resname="tx_kesearch_indexerconfig.file_collections" >
+				<source>File collections</source>
+			</trans-unit>
 			<trans-unit id="tx_kesearch_indexerconfig.directories" resname="tx_kesearch_indexerconfig.directories" >
 				<source>Directories</source>
 			</trans-unit>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -136,6 +136,7 @@ CREATE TABLE tx_kesearch_indexerconfig (
 	fileext tinytext,
 	content_fields text,
 	file_reference_fields text,
+	file_collections text,
 	filteroption int(11) DEFAULT '0' NOT NULL,
 	fal_storage int(11) DEFAULT '0' NOT NULL,
 	contenttypes text,


### PR DESCRIPTION
As mentioned in #294, this is something we added in a specific project but thought it would be beneficial to have in the core package.

Currently, selecting a FAL storage makes the field appear - this is a small hack so that [this conditional triggers](https://github.com/tpwd/ke_search/blob/master/Classes/Indexer/Types/File.php#L445).

I'm not expecting this hack to stay, but wanted to get the rest of the code in there to start review & conversation.

I was toying with the idea of either adding an extra item to the `fal_storage` field (e.g  "File Collections"  with a value of 9999) or adding a new field of `file_type` or similar which has  "Directories" and "File Collections" as an option, as I can't imagine people would want to mix and match (and, in fact, would cause conflicting and confusing UI).

I think the second would be better, so the directory related code could then be abstracted out into it's own method