### PR TITLE
[BUGFIX] Fix undefined array_key PHP Warning in Page indexer

### DIFF
--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -169,8 +169,8 @@ class Page extends IndexerBase
         /** @var TranslationConfigurationProvider $translationProvider */
         $translationProvider = GeneralUtility::makeInstance(TranslationConfigurationProvider::class);
         $startingPoints = [];
-        $startingPoints += GeneralUtility::trimExplode(',', $this->indexerConfig['startingpoints_recursive'], true);
-        $startingPoints += GeneralUtility::trimExplode(',', $this->indexerConfig['single_pages'], true);
+        $startingPoints += GeneralUtility::trimExplode(',', $this->indexerConfig['startingpoints_recursive'] ?? '', true);
+        $startingPoints += GeneralUtility::trimExplode(',', $this->indexerConfig['single_pages'] ?? '', true);
         foreach ($startingPoints as $startingPoint) {
             foreach ($translationProvider->getSystemLanguages((int)$startingPoint) as $key => $lang) {
                 $this->sysLanguages[$key] = $lang;


### PR DESCRIPTION
When opening the form engine of a search configuration, I get the following error message:

```
An error occurred trying to process items for field "Type" (PHP Warning: Undefined array key "startingpoints_recursive" in /var/www/html/vendor/tpwd/ke_search/Classes/Indexer/Types/Page.php line 172).
```
