### PR TITLE
[BUGFIX] Fix possible error on processing missing file

### DIFF
--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -46,6 +46,6 @@ class FileUtility
             $file->getExtension()
         );
 
-        return !$isExcludedFromSearch && $isInList;
+        return !$isExcludedFromSearch && $isInList && !$file->isMissing();
     }
 }


### PR DESCRIPTION
If a FAL storage is externally changed (e.g. by OS s3 integration or "andersundsehr/aus-driver-amazon-s3") the TYPO3 records in sys_file remain untouched. The Scheduler Task "File Abstraction Layer: Update storage index (scheduler)" can mark these files as missing.

As missing declared files should not be processed, this could lead to errors.