### PR TITLE
[FIX] TYPO3 v14 deprecations on the search results page

### DIFF
--- a/Classes/Lib/Searchresult.php
+++ b/Classes/Lib/Searchresult.php
@@ -2,6 +2,7 @@
 
 namespace Tpwd\KeSearch\Lib;
 
+use Psr\Http\Message\ServerRequestInterface;
 use Tpwd\KeSearch\Utility\ContentUtility;
 use TYPO3\CMS\Core\Text\TextCropper;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -36,10 +37,20 @@ class Searchresult
     private array $swords = [];
     private array $conf = [];
     private array $extConfPremium;
+    private ?ServerRequestInterface $request = null;
 
     public function __construct()
     {
         $this->extConfPremium = SearchHelper::getExtConfPremium();
+    }
+
+    /**
+     * Sets the current request so the ContentObjectRenderer instances created
+     * in this class can resolve links without falling back to $GLOBALS['TYPO3_REQUEST'].
+     */
+    public function setRequest(ServerRequestInterface $request): void
+    {
+        $this->request = $request;
     }
 
     /**
@@ -77,7 +88,7 @@ class Searchresult
      */
     public function getTitle(): string
     {
-        $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $cObj = $this->makeContentObjectRenderer();
         // configure the link
         $linkconf = $this->getResultLinkConfiguration();
 
@@ -113,7 +124,7 @@ class Searchresult
      */
     public function getResultUrl($linked = false): string
     {
-        $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $cObj = $this->makeContentObjectRenderer();
         $linkText = $cObj->typoLink_URL($this->getResultLinkConfiguration());
         $linkText = htmlspecialchars($linkText);
         if ($linked) {
@@ -205,7 +216,7 @@ class Searchresult
      */
     public function highlightArrayOfWordsInContent(array $wordArray, string $content): string
     {
-        $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $cObj = $this->makeContentObjectRenderer();
         if (count($wordArray)) {
             $highlightedWord = (!empty($this->conf['highlightedWord_stdWrap'])) ?
                 $cObj->stdWrap('\0', $this->conf['highlightedWord_stdWrap']) :
@@ -342,5 +353,18 @@ class Searchresult
                     replacementForEllipsis: '…',
                     cropToSpace: true
                 );
+    }
+
+    /**
+     * Creates a ContentObjectRenderer and injects the current request (if available)
+     * so typoLink/stdWrap don't fall back to $GLOBALS['TYPO3_REQUEST'] (deprecated since v14).
+     */
+    private function makeContentObjectRenderer(): ContentObjectRenderer
+    {
+        $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        if ($this->request !== null) {
+            $cObj->setRequest($this->request);
+        }
+        return $cObj;
     }
 }

--- a/Classes/Plugins/PluginBase.php
+++ b/Classes/Plugins/PluginBase.php
@@ -400,12 +400,13 @@ class PluginBase extends AbstractPlugin
 
         // set form action pid
         $this->fluidTemplateVariables['targetpage'] = $this->conf['resultPage'];
+        $targetPageContentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $targetPageContentObject->setRequest($this->request);
         $this->fluidTemplateVariables['targetPageUrl']
-            = GeneralUtility::makeInstance(ContentObjectRenderer::class)
-            ->typoLink_URL(['parameter' => $this->conf['resultPage']]);
+            = $targetPageContentObject->typoLink_URL(['parameter' => $this->conf['resultPage']]);
 
         // set form action
-        $siteUrl = GeneralUtility::getIndpEnv('TYPO3_SITE_URL');
+        $siteUrl = $this->request->getAttribute('normalizedParams')->getSiteUrl();
         $lParam = RequestUtility::getQueryParam($this->request, 'L');
         $mpParam = RequestUtility::getQueryParam($this->request, 'MP');
         $typeParam = RequestUtility::getQueryParam($this->request, 'type');
@@ -731,6 +732,7 @@ class PluginBase extends AbstractPlugin
         // init counter and loop through the search results
         $resultCount = 1;
         $resultRowRenderer = GeneralUtility::makeInstance(Searchresult::class);
+        $resultRowRenderer->setRequest($this->request);
         $resultRowRenderer->setPluginConfiguration($this->conf);
         $resultRowRenderer->setSwords($this->swords);
 


### PR DESCRIPTION
  ### Summary

  Rendering a search results page currently triggers TYPO3 v14 deprecation notices that are scheduled for removal in v15. Both originate from `ContentObjectRenderer` instances created via `GeneralUtility::makeInstance()` **without** calling `setRequest()` before invoking `typoLink()`, `typoLink_URL()` or `stdWrap()`, which then fall back to `$GLOBALS['TYPO3_REQUEST']`:

  > Fallback to `$GLOBALS['TYPO3_REQUEST']` in `ContentObjectRenderer::getRequest()` is deprecated since TYPO3 v14 and will be removed in v15. Call `setRequest()` after object instantiation.

  > `GeneralUtility::getIndpEnv()` is deprecated since TYPO3 v14.3 and will be removed in v15.0. Use `NormalizedParams` from the PSR-7 request instead.

  The `getRequest()` fallback fires **once per result row**, producing hundreds of notices on a populated result list. It can also already throw a `ContentRenderingException` in contexts where no global request is available.

  ### Changes

  - **`PluginBase::getSearchboxContent()`** — inject the current request into the `ContentObjectRenderer` used for the `targetPageUrl`, and replace `GeneralUtility::getIndpEnv('TYPO3_SITE_URL')` with `$this->request->getAttribute('normalizedParams')->getSiteUrl()`.
  - **`PluginBase::getSearchResults()`** — pass the request to the `Searchresult` row renderer before the result loop.
  - **`Searchresult`** — add a `setRequest()` setter and a small private `makeContentObjectRenderer()` helper that injects the request (when available). The three call sites (`getTitle()`, `getResultUrl()`, `highlightArrayOfWordsInContent()`) now use this helper instead of creating a bare renderer.

  ### Compatibility

  Both `ContentObjectRenderer::setRequest()` and the PSR-7 `NormalizedParams` attribute exist in **TYPO3 v13 and v14**, so no version switch is required. `NormalizedParams::getSiteUrl()` returns the same trailing-slash site URL as the previous `getIndpEnv()` call, keeping the generated form action URL identical. The request injection is guarded against `null`, so behaviour is unchanged when no request is 
  present.

  ### Notes / out of scope
  
  - The `getRequest()` notices on the result list are eliminated; the `stdWrap` path in `highlightArrayOfWordsInContent()` only applied when `highlightedWord_stdWrap` is configured, but is now covered as well.
  - `AttachedFilesService::findAttachedFiles()` (line 25) uses the same pattern but runs in the **indexing (BE/CLI) context**, where a request may not exist. It is intentionally left out of this PR, as it needs a guarded approach plus functional test coverage.
